### PR TITLE
Remove zip files to reduce repo size.

### DIFF
--- a/output.zip
+++ b/output.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1a9131baa1ce21f807e5bdd9f3ae200cd762aa5e85a5abb288e193fcb43d13ca
-size 1311324642

--- a/train.zip
+++ b/train.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0dcc87b171f740787052c51ba2bfc5cf4e5431a81a55c1d3d22ca47afb0bd75e
-size 610838231


### PR DESCRIPTION
# Description
Removes "train.zip" and "output.zip" which consume a lot of space in the repo but cause errors after the repo is cloned. They are not necessary as we have a new trained language file that will not need anymore training data or outdated output data. Removing to reduce repo size eliminate errors during cloning